### PR TITLE
Adds convenience methods for voids returning via references to UnrealEngine.Framework

### DIFF
--- a/Source/Managed/Framework/Framework.cs
+++ b/Source/Managed/Framework/Framework.cs
@@ -3109,16 +3109,34 @@ namespace UnrealEngine.Framework {
 		public static uint FrameNumber => getFrameNumber();
 
 		/// <summary>
-		/// Retrieves the current size of the viewport
+		/// Retrieves the current size of the viewport and returns to a reference
 		/// </summary>
 		public static void GetViewportSize(ref Vector2 value) => getViewportSize(ref value);
 
+        /// <summary>
+        /// Retrieves the current size of the viewport
+        /// </summary>
+		public static Vector2 GetViewportSize() {
+            Vector2 value = default;
+            getViewportSize(ref value);
+            return value;
+        }
+
 		/// <summary>
-		/// Retrieves the current resolution of the screen
+		/// Retrieves the current resolution of the screen and returns to a reference
 		/// </summary>
 		public static void GetScreenResolution(ref Vector2 value) => getScreenResolution(ref value);
 
-		/// <summary>
+        /// <summary>
+        /// Retrieves the current resolution of the screen
+        /// </summary>
+		public static Vector2 GetScreenResolution() {
+            Vector2 value = default;
+            getScreenResolution(ref value);
+            return value;
+		}
+
+        /// <summary>
 		/// Returns the current mode of the window
 		/// </summary>
 		public static WindowMode WindowMode => getWindowMode();
@@ -3351,11 +3369,20 @@ namespace UnrealEngine.Framework {
 		}
 
 		/// <summary>
-		/// Retrieves the current location of the <a href="https://docs.unrealengine.com/en-US/Engine/LevelStreaming/WorldBrowser/index.html">world origin</a>
+		/// Retrieves the current location of the <a href="https://docs.unrealengine.com/en-US/Engine/LevelStreaming/WorldBrowser/index.html">world origin</a> to a reference
 		/// </summary>
 		public static void GetWorldOrigin(ref Vector3 value) => getWorldOrigin(ref value);
 
-		/// <summary>
+        /// <summary>
+        /// Retrieves the current location of the <a href="https://docs.unrealengine.com/en-US/Engine/LevelStreaming/WorldBrowser/index.html">world origin</a>
+        /// </summary>
+        public static Vector3 GetWorldOrigin() {
+            Vector3 value = default;
+            getWorldOrigin(ref value);
+            return value;
+        }
+
+        /// <summary>
 		/// Sets the static callback function that is called when actors start overlapping
 		/// </summary>
 		/// <param name="callback">The static function to call when an actor start overlapping with another one</param>
@@ -4466,9 +4493,18 @@ namespace UnrealEngine.Framework {
 		public void AddMovementInput(in Vector3 worldDirection, float scaleValue = 1.0f, bool force = false) => addMovementInput(Pointer, worldDirection, scaleValue, force);
 
 		/// <summary>
-		/// Retrieves vector direction of gravity
+		/// Retrieves vector direction of gravity and returns to a reference
 		/// </summary>
 		public void GetGravityDirection(ref Vector3 value) => getGravityDirection(Pointer, ref value);
+
+        /// <summary>
+        /// Retrieves vector direction of gravity
+        /// </summary>
+        public Vector3 GetGravityDirection() {
+            Vector3 value = default;
+            getGravityDirection(Pointer, ref value);
+            return value;
+        }
 	}
 
 	/// <summary>
@@ -4609,9 +4645,18 @@ namespace UnrealEngine.Framework {
 		public void ClearFocus(AIFocusPriority priority = AIFocusPriority.High) => clearFocus(Pointer, priority);
 
 		/// <summary>
-		/// Retrieves the final position that controller should be looking at
+		/// Retrieves the final position that controller should be looking at and returns to a reference
 		/// </summary>
 		public void GetFocalPoint(ref Vector3 value) => getFocalPoint(Pointer, ref value);
+
+        /// <summary>
+        /// Retrieves the final position that controller should be looking at
+        /// </summary>
+        public Vector3 GetFocalPoint() {
+            Vector3 value = default;
+            getFocalPoint(Pointer, ref value);
+            return value;
+        }
 
 		/// <summary>
 		/// Sets focal point for the given priority as absolute position or offset from base
@@ -5740,9 +5785,18 @@ namespace UnrealEngine.Framework {
 		}
 
 		/// <summary>
-		/// Retrieves mouse sensitivity
+		/// Retrieves mouse sensitivity and returns to a reference
 		/// </summary>
 		public void GetMouseSensitivity(ref Vector2 value) => getMouseSensitivity(Pointer, ref value);
+
+        /// <summary>
+        /// Retrieves mouse sensitivity
+        /// </summary>
+        public Vector2 GetMouseSensitivity() {
+            Vector2 value = default;
+            getMouseSensitivity(Pointer, ref value);
+            return value;
+        }
 
 		/// <summary>
 		/// Sets mouse sensitivity
@@ -5959,9 +6013,18 @@ namespace UnrealEngine.Framework {
 		}
 
 		/// <summary>
-		/// Retrieves size of the texture
+		/// Retrieves size of the texture and returns to a reference
 		/// </summary>
 		public void GetSize(ref Vector2 value) => getSize(Pointer, ref value);
+
+        /// <summary>
+        /// Retrieves size of the texture
+        /// </summary>
+        public Vector2 GetSize() {
+            Vector2 value = default;
+            getSize(Pointer, ref value);
+            return value;
+        }
 	}
 
 	/// <summary>
@@ -6567,54 +6630,144 @@ namespace UnrealEngine.Framework {
 		}
 
 		/// <summary>
-		/// Retrieves location of a socket in world space
+		/// Retrieves location of a socket in world space and returns to a reference
 		/// </summary>
 		public void GetSocketLocation(string socketName, ref Vector3 value) => getSocketLocation(Pointer, socketName, ref value);
 
+        /// <summary>
+        /// Retrieves location of a socket in world space
+        /// </summary>
+        public Vector3 GetSocketLocation(string socketName) {
+            Vector3 value = default;
+            getSocketLocation(Pointer, socketName, ref value);
+            return value;
+        }
+
 		/// <summary>
-		/// Retrieves rotation of a socket in world space
+		/// Retrieves rotation of a socket in world space and returns to a reference
 		/// </summary>
 		public void GetSocketRotation(string socketName, ref Quaternion value) => getSocketRotation(Pointer, socketName, ref value);
 
+        /// <summary>
+        /// Retrieves rotation of a socket in world space
+        /// </summary>
+        public Quaternion GetSocketRotation(string socketName) {
+            Quaternion value = default;
+            getSocketRotation(Pointer, socketName, ref value);
+            return value;
+        }
+
 		/// <summary>
-		/// Retrieves velocity of the component, or the velocity of the physics body if simulating physics
+		/// Retrieves velocity of the component, or the velocity of the physics body if simulating physics and returns to a reference
 		/// </summary>
 		public void GetVelocity(ref Vector3 value) => getComponentVelocity(Pointer, ref value);
 
-		/// <summary>
-		/// Retrieves location of the component in world space
+        /// <summary>
+        /// Retrieves velocity of the component, or the velocity of the physics body if simulating physics
+        /// </summary>
+        public Vector3 GetVelocity() {
+            Vector3 value = default;
+            getComponentVelocity(Pointer, ref value);
+            return value;
+        }
+
+        /// <summary>
+		/// Retrieves location of the component in world space and returns to a reference
 		/// </summary>
 		public void GetLocation(ref Vector3 value) => getComponentLocation(Pointer, ref value);
 
-		/// <summary>
-		/// Retrieves rotation of the component in world space
+        /// <summary>
+        /// Retrieves location of the component in world space
+        /// </summary>
+        public Vector3 GetLocation() {
+            Vector3 value = default;
+            getComponentLocation(Pointer, ref value);
+            return value;
+        }
+
+        /// <summary>
+		/// Retrieves rotation of the component in world space and returns to a reference
 		/// </summary>
 		public void GetRotation(ref Quaternion value) => getComponentRotation(Pointer, ref value);
 
+        /// <summary>
+        /// Retrieves rotation of the component in world space
+        /// </summary>
+        public Quaternion GetRotation() {
+            Quaternion value = default;
+            getComponentRotation(Pointer, ref value);
+            return value;
+        }
+
 		/// <summary>
-		/// Retrieves scale of the component in world space
+		/// Retrieves scale of the component in world space and returns to a reference
 		/// </summary>
 		public void GetScale(ref Vector3 value) => getComponentScale(Pointer, ref value);
 
+        /// <summary>
+        /// Retrieves scale of the component in world space
+        /// </summary>
+        public Vector3 GetScale() {
+            Vector3 value = default;
+            getComponentScale(Pointer, ref value);
+            return value;
+        }
+
 		/// <summary>
-		/// Retrieves the transform which assigned to the component
+		/// Retrieves the transform which assigned to the component and returns to a reference
 		/// </summary>
 		public void GetTransform(ref Transform value) => SceneComponent.getComponentTransform(Pointer, ref value);
 
-		/// <summary>
-		/// Retrieves the forward X unit direction vector from the component in world space
+        /// <summary>
+        /// Retrieves the transform which assigned to the component
+        /// </summary>
+        public Transform GetTransform() {
+            Transform value = default;
+            SceneComponent.getComponentTransform(Pointer, ref value);
+            return value;
+        }
+
+        /// <summary>
+		/// Retrieves the forward X unit direction vector from the component in world space and returns to a reference
 		/// </summary>
 		public void GetForwardVector(ref Vector3 value) => getForwardVector(Pointer, ref value);
 
-		/// <summary>
-		/// Retrieves the right Y unit direction vector from the component in world space
+        /// <summary>
+        /// Retrieves the forward X unit direction vector from the component in world space
+        /// </summary>
+        public Vector3 GetForwardVector() {
+            Vector3 value = default;
+            getForwardVector(Pointer, ref value);
+            return value;
+        }
+
+        /// <summary>
+		/// Retrieves the right Y unit direction vector from the component in world space and returns to a reference
 		/// </summary>
 		public void GetRightVector(ref Vector3 value) => getRightVector(Pointer, ref value);
 
+        /// <summary>
+        /// Retrieves the right Y unit direction vector from the component in world space
+        /// </summary>
+        public Vector3 GetRightVector() {
+            Vector3 value = default;
+            getRightVector(Pointer, ref value);
+            return value;
+        }
+
 		/// <summary>
-		/// Retrieves the up Z unit direction vector from the component in world space
+		/// Retrieves the up Z unit direction vector from the component in world space and returns to a reference
 		/// </summary>
 		public void GetUpVector(ref Vector3 value) => getUpVector(Pointer, ref value);
+
+        /// <summary>
+        /// Retrieves the up Z unit direction vector from the component in world space
+        /// </summary>
+        public Vector3 GetUpVector() {
+            Vector3 value = default;
+            getUpVector(Pointer, ref value);
+            return value;
+        }
 
 		/// <summary>
 		/// Sets how often the component is allowed to move at runtime
@@ -7035,24 +7188,60 @@ namespace UnrealEngine.Framework {
 		public void AddTorqueInRadians(in Vector3 torque, string boneName = null, bool accelerationChange = false) => addTorqueInRadians(Pointer, torque, boneName, accelerationChange);
 
 		/// <summary>
-		/// Retrieves the linear velocity of a single body
+		/// Retrieves the linear velocity of a single body and returns to a reference
 		/// </summary>
 		public void GetPhysicsLinearVelocity(ref Vector3 value, string boneName = null) => getPhysicsLinearVelocity(Pointer, ref value, boneName);
 
+        /// <summary>
+        /// Retrieves the linear velocity of a single body
+        /// </summary>
+        public Vector3 GetPhysicsLinearVelocity(string boneName = null) {
+            Vector3 value = default;
+            getPhysicsLinearVelocity(Pointer, ref value, boneName);
+            return value;
+        }
+
 		/// <summary>
-		/// Retrieves the linear velocity of a point on a single body
+		/// Retrieves the linear velocity of a point on a single body and returns to a reference
 		/// </summary>
 		public void GetPhysicsLinearVelocityAtPoint(ref Vector3 value, in Vector3 point, string boneName = null) => getPhysicsLinearVelocityAtPoint(Pointer, ref value, point, boneName);
 
+        /// <summary>
+        /// Retrieves the linear velocity of a point on a single body
+        /// </summary>
+        public Vector3 GetPhysicsLinearVelocityAtPoint(in Vector3 point, string boneName = null) {
+            Vector3 value = default;
+            getPhysicsLinearVelocityAtPoint(Pointer, ref value, point, boneName);
+            return value;
+        }
+
 		/// <summary>
-		/// Retrieves the angular velocity in degrees of a single body
+		/// Retrieves the angular velocity in degrees of a single body and returns to a reference
 		/// </summary>
 		public void GetPhysicsAngularVelocityInDegrees(ref Vector3 value, string boneName = null) => getPhysicsAngularVelocityInDegrees(Pointer, ref value, boneName);
 
+        /// <summary>
+        /// Retrieves the angular velocity in degrees of a single body
+        /// </summary>
+        public Vector3 GetPhysicsAngularVelocityInDegrees(string boneName = null) {
+            Vector3 value = default;
+            getPhysicsAngularVelocityInDegrees(Pointer, ref value, boneName);
+            return value;
+        }
+
 		/// <summary>
-		/// Retrieves the angular velocity in radians of a single body
+		/// Retrieves the angular velocity in radians of a single body and returns to a reference
 		/// </summary>
 		public void GetPhysicsAngularVelocityInRadians(ref Vector3 value, string boneName = null) => getPhysicsAngularVelocityInRadians(Pointer, ref value, boneName);
+
+        /// <summary>
+        /// Retrieves the angular velocity in radians of a single body
+        /// </summary>
+        public Vector3 GetPhysicsAngularVelocityInRadians(string boneName = null) {
+            Vector3 value = default;
+            getPhysicsAngularVelocityInRadians(Pointer, ref value, boneName);
+            return value;
+        }
 
 		/// <summary>
 		/// Returns the material at the specified element index
@@ -7277,14 +7466,32 @@ namespace UnrealEngine.Framework {
 		}
 
 		/// <summary>
-		/// Retrieves the box extents scaled by the component scale
+		/// Retrieves the box extents scaled by the component scale and returns to a reference
 		/// </summary>
 		public void GetScaledBoxExtent(ref Vector3 value) => getScaledBoxExtent(Pointer, ref value);
 
+        /// <summary>
+        /// Retrieves the box extents scaled by the component scale
+        /// </summary>
+        public Vector3 GetScaledBoxExtent() {
+            Vector3 value = default;
+            getScaledBoxExtent(Pointer, ref value);
+            return value;
+        }
+
 		/// <summary>
-		/// Retrieves the box extent ignoring the component scale
+		/// Retrieves the box extent ignoring the component scale and returns to a reference
 		/// </summary>
 		public void GetUnscaledBoxExtent(ref Vector3 value) => getUnscaledBoxExtent(Pointer, ref value);
+
+        /// <summary>
+        /// Retrieves the box extent ignoring the component scale
+        /// </summary>
+        public Vector3 GetUnscaledBoxExtent() {
+            Vector3 value = default;
+            getUnscaledBoxExtent(Pointer, ref value);
+            return value;
+        }
 
 		/// <summary>
 		/// Sets the box extent size, unscaled before the component scale is applied

--- a/Source/Managed/Framework/Framework.cs
+++ b/Source/Managed/Framework/Framework.cs
@@ -3113,30 +3113,30 @@ namespace UnrealEngine.Framework {
 		/// </summary>
 		public static void GetViewportSize(ref Vector2 value) => getViewportSize(ref value);
 
-        /// <summary>
-        /// Retrieves the current size of the viewport
-        /// </summary>
+		/// <summary>
+		/// Retrieves the current size of the viewport
+		/// </summary>
 		public static Vector2 GetViewportSize() {
-            Vector2 value = default;
-            getViewportSize(ref value);
-            return value;
-        }
+			Vector2 value = default;
+			getViewportSize(ref value);
+			return value;
+		}
 
 		/// <summary>
 		/// Retrieves the current resolution of the screen and returns to a reference
 		/// </summary>
 		public static void GetScreenResolution(ref Vector2 value) => getScreenResolution(ref value);
 
-        /// <summary>
-        /// Retrieves the current resolution of the screen
-        /// </summary>
+		/// <summary>
+		/// Retrieves the current resolution of the screen
+		/// </summary>
 		public static Vector2 GetScreenResolution() {
-            Vector2 value = default;
-            getScreenResolution(ref value);
-            return value;
+			Vector2 value = default;
+			getScreenResolution(ref value);
+			return value;
 		}
 
-        /// <summary>
+		/// <summary>
 		/// Returns the current mode of the window
 		/// </summary>
 		public static WindowMode WindowMode => getWindowMode();
@@ -3373,16 +3373,16 @@ namespace UnrealEngine.Framework {
 		/// </summary>
 		public static void GetWorldOrigin(ref Vector3 value) => getWorldOrigin(ref value);
 
-        /// <summary>
-        /// Retrieves the current location of the <a href="https://docs.unrealengine.com/en-US/Engine/LevelStreaming/WorldBrowser/index.html">world origin</a>
-        /// </summary>
-        public static Vector3 GetWorldOrigin() {
-            Vector3 value = default;
-            getWorldOrigin(ref value);
-            return value;
-        }
+		/// <summary>
+		/// Retrieves the current location of the <a href="https://docs.unrealengine.com/en-US/Engine/LevelStreaming/WorldBrowser/index.html">world origin</a>
+		/// </summary>
+		public static Vector3 GetWorldOrigin() {
+			Vector3 value = default;
+			getWorldOrigin(ref value);
+			return value;
+		}
 
-        /// <summary>
+		/// <summary>
 		/// Sets the static callback function that is called when actors start overlapping
 		/// </summary>
 		/// <param name="callback">The static function to call when an actor start overlapping with another one</param>
@@ -4497,14 +4497,14 @@ namespace UnrealEngine.Framework {
 		/// </summary>
 		public void GetGravityDirection(ref Vector3 value) => getGravityDirection(Pointer, ref value);
 
-        /// <summary>
-        /// Retrieves vector direction of gravity
-        /// </summary>
-        public Vector3 GetGravityDirection() {
-            Vector3 value = default;
-            getGravityDirection(Pointer, ref value);
-            return value;
-        }
+		/// <summary>
+		/// Retrieves vector direction of gravity
+		/// </summary>
+		public Vector3 GetGravityDirection() {
+			Vector3 value = default;
+			getGravityDirection(Pointer, ref value);
+			return value;
+		}
 	}
 
 	/// <summary>
@@ -4649,14 +4649,14 @@ namespace UnrealEngine.Framework {
 		/// </summary>
 		public void GetFocalPoint(ref Vector3 value) => getFocalPoint(Pointer, ref value);
 
-        /// <summary>
-        /// Retrieves the final position that controller should be looking at
-        /// </summary>
-        public Vector3 GetFocalPoint() {
-            Vector3 value = default;
-            getFocalPoint(Pointer, ref value);
-            return value;
-        }
+		/// <summary>
+		/// Retrieves the final position that controller should be looking at
+		/// </summary>
+		public Vector3 GetFocalPoint() {
+			Vector3 value = default;
+			getFocalPoint(Pointer, ref value);
+			return value;
+		}
 
 		/// <summary>
 		/// Sets focal point for the given priority as absolute position or offset from base
@@ -5789,14 +5789,14 @@ namespace UnrealEngine.Framework {
 		/// </summary>
 		public void GetMouseSensitivity(ref Vector2 value) => getMouseSensitivity(Pointer, ref value);
 
-        /// <summary>
-        /// Retrieves mouse sensitivity
-        /// </summary>
-        public Vector2 GetMouseSensitivity() {
-            Vector2 value = default;
-            getMouseSensitivity(Pointer, ref value);
-            return value;
-        }
+		/// <summary>
+		/// Retrieves mouse sensitivity
+		/// </summary>
+		public Vector2 GetMouseSensitivity() {
+			Vector2 value = default;
+			getMouseSensitivity(Pointer, ref value);
+			return value;
+		}
 
 		/// <summary>
 		/// Sets mouse sensitivity
@@ -6017,14 +6017,14 @@ namespace UnrealEngine.Framework {
 		/// </summary>
 		public void GetSize(ref Vector2 value) => getSize(Pointer, ref value);
 
-        /// <summary>
-        /// Retrieves size of the texture
-        /// </summary>
-        public Vector2 GetSize() {
-            Vector2 value = default;
-            getSize(Pointer, ref value);
-            return value;
-        }
+		/// <summary>
+		/// Retrieves size of the texture
+		/// </summary>
+		public Vector2 GetSize() {
+			Vector2 value = default;
+			getSize(Pointer, ref value);
+			return value;
+		}
 	}
 
 	/// <summary>
@@ -6634,140 +6634,140 @@ namespace UnrealEngine.Framework {
 		/// </summary>
 		public void GetSocketLocation(string socketName, ref Vector3 value) => getSocketLocation(Pointer, socketName, ref value);
 
-        /// <summary>
-        /// Retrieves location of a socket in world space
-        /// </summary>
-        public Vector3 GetSocketLocation(string socketName) {
-            Vector3 value = default;
-            getSocketLocation(Pointer, socketName, ref value);
-            return value;
-        }
+		/// <summary>
+		/// Retrieves location of a socket in world space
+		/// </summary>
+		public Vector3 GetSocketLocation(string socketName) {
+			Vector3 value = default;
+			getSocketLocation(Pointer, socketName, ref value);
+			return value;
+		}
 
 		/// <summary>
 		/// Retrieves rotation of a socket in world space and returns to a reference
 		/// </summary>
 		public void GetSocketRotation(string socketName, ref Quaternion value) => getSocketRotation(Pointer, socketName, ref value);
 
-        /// <summary>
-        /// Retrieves rotation of a socket in world space
-        /// </summary>
-        public Quaternion GetSocketRotation(string socketName) {
-            Quaternion value = default;
-            getSocketRotation(Pointer, socketName, ref value);
-            return value;
-        }
+		/// <summary>
+		/// Retrieves rotation of a socket in world space
+		/// </summary>
+		public Quaternion GetSocketRotation(string socketName) {
+			Quaternion value = default;
+			getSocketRotation(Pointer, socketName, ref value);
+			return value;
+		}
 
 		/// <summary>
 		/// Retrieves velocity of the component, or the velocity of the physics body if simulating physics and returns to a reference
 		/// </summary>
 		public void GetVelocity(ref Vector3 value) => getComponentVelocity(Pointer, ref value);
 
-        /// <summary>
-        /// Retrieves velocity of the component, or the velocity of the physics body if simulating physics
-        /// </summary>
-        public Vector3 GetVelocity() {
-            Vector3 value = default;
-            getComponentVelocity(Pointer, ref value);
-            return value;
-        }
+		/// <summary>
+		/// Retrieves velocity of the component, or the velocity of the physics body if simulating physics
+		/// </summary>
+		public Vector3 GetVelocity() {
+			Vector3 value = default;
+			getComponentVelocity(Pointer, ref value);
+			return value;
+		}
 
-        /// <summary>
+		/// <summary>
 		/// Retrieves location of the component in world space and returns to a reference
 		/// </summary>
 		public void GetLocation(ref Vector3 value) => getComponentLocation(Pointer, ref value);
 
-        /// <summary>
-        /// Retrieves location of the component in world space
-        /// </summary>
-        public Vector3 GetLocation() {
-            Vector3 value = default;
-            getComponentLocation(Pointer, ref value);
-            return value;
-        }
+		/// <summary>
+		/// Retrieves location of the component in world space
+		/// </summary>
+		public Vector3 GetLocation() {
+			Vector3 value = default;
+			getComponentLocation(Pointer, ref value);
+			return value;
+		}
 
-        /// <summary>
+		/// <summary>
 		/// Retrieves rotation of the component in world space and returns to a reference
 		/// </summary>
 		public void GetRotation(ref Quaternion value) => getComponentRotation(Pointer, ref value);
 
-        /// <summary>
-        /// Retrieves rotation of the component in world space
-        /// </summary>
-        public Quaternion GetRotation() {
-            Quaternion value = default;
-            getComponentRotation(Pointer, ref value);
-            return value;
-        }
+		/// <summary>
+		/// Retrieves rotation of the component in world space
+		/// </summary>
+		public Quaternion GetRotation() {
+			Quaternion value = default;
+			getComponentRotation(Pointer, ref value);
+			return value;
+		}
 
 		/// <summary>
 		/// Retrieves scale of the component in world space and returns to a reference
 		/// </summary>
 		public void GetScale(ref Vector3 value) => getComponentScale(Pointer, ref value);
 
-        /// <summary>
-        /// Retrieves scale of the component in world space
-        /// </summary>
-        public Vector3 GetScale() {
-            Vector3 value = default;
-            getComponentScale(Pointer, ref value);
-            return value;
-        }
+		/// <summary>
+		/// Retrieves scale of the component in world space
+		/// </summary>
+		public Vector3 GetScale() {
+			Vector3 value = default;
+			getComponentScale(Pointer, ref value);
+			return value;
+		}
 
 		/// <summary>
 		/// Retrieves the transform which assigned to the component and returns to a reference
 		/// </summary>
 		public void GetTransform(ref Transform value) => SceneComponent.getComponentTransform(Pointer, ref value);
 
-        /// <summary>
-        /// Retrieves the transform which assigned to the component
-        /// </summary>
-        public Transform GetTransform() {
-            Transform value = default;
-            SceneComponent.getComponentTransform(Pointer, ref value);
-            return value;
-        }
+		/// <summary>
+		/// Retrieves the transform which assigned to the component
+		/// </summary>
+		public Transform GetTransform() {
+			Transform value = default;
+			SceneComponent.getComponentTransform(Pointer, ref value);
+			return value;
+		}
 
-        /// <summary>
+		/// <summary>
 		/// Retrieves the forward X unit direction vector from the component in world space and returns to a reference
 		/// </summary>
 		public void GetForwardVector(ref Vector3 value) => getForwardVector(Pointer, ref value);
 
-        /// <summary>
-        /// Retrieves the forward X unit direction vector from the component in world space
-        /// </summary>
-        public Vector3 GetForwardVector() {
-            Vector3 value = default;
-            getForwardVector(Pointer, ref value);
-            return value;
-        }
+		/// <summary>
+		/// Retrieves the forward X unit direction vector from the component in world space
+		/// </summary>
+		public Vector3 GetForwardVector() {
+			Vector3 value = default;
+			getForwardVector(Pointer, ref value);
+			return value;
+		}
 
-        /// <summary>
+		/// <summary>
 		/// Retrieves the right Y unit direction vector from the component in world space and returns to a reference
 		/// </summary>
 		public void GetRightVector(ref Vector3 value) => getRightVector(Pointer, ref value);
 
-        /// <summary>
-        /// Retrieves the right Y unit direction vector from the component in world space
-        /// </summary>
-        public Vector3 GetRightVector() {
-            Vector3 value = default;
-            getRightVector(Pointer, ref value);
-            return value;
-        }
+		/// <summary>
+		/// Retrieves the right Y unit direction vector from the component in world space
+		/// </summary>
+		public Vector3 GetRightVector() {
+			Vector3 value = default;
+			getRightVector(Pointer, ref value);
+			return value;
+		}
 
 		/// <summary>
 		/// Retrieves the up Z unit direction vector from the component in world space and returns to a reference
 		/// </summary>
 		public void GetUpVector(ref Vector3 value) => getUpVector(Pointer, ref value);
 
-        /// <summary>
-        /// Retrieves the up Z unit direction vector from the component in world space
-        /// </summary>
-        public Vector3 GetUpVector() {
-            Vector3 value = default;
-            getUpVector(Pointer, ref value);
-            return value;
-        }
+		/// <summary>
+		/// Retrieves the up Z unit direction vector from the component in world space
+		/// </summary>
+		public Vector3 GetUpVector() {
+			Vector3 value = default;
+			getUpVector(Pointer, ref value);
+			return value;
+		}
 
 		/// <summary>
 		/// Sets how often the component is allowed to move at runtime
@@ -7192,56 +7192,56 @@ namespace UnrealEngine.Framework {
 		/// </summary>
 		public void GetPhysicsLinearVelocity(ref Vector3 value, string boneName = null) => getPhysicsLinearVelocity(Pointer, ref value, boneName);
 
-        /// <summary>
-        /// Retrieves the linear velocity of a single body
-        /// </summary>
-        public Vector3 GetPhysicsLinearVelocity(string boneName = null) {
-            Vector3 value = default;
-            getPhysicsLinearVelocity(Pointer, ref value, boneName);
-            return value;
-        }
+		/// <summary>
+		/// Retrieves the linear velocity of a single body
+		/// </summary>
+		public Vector3 GetPhysicsLinearVelocity(string boneName = null) {
+			Vector3 value = default;
+			getPhysicsLinearVelocity(Pointer, ref value, boneName);
+			return value;
+		}
 
 		/// <summary>
 		/// Retrieves the linear velocity of a point on a single body and returns to a reference
 		/// </summary>
 		public void GetPhysicsLinearVelocityAtPoint(ref Vector3 value, in Vector3 point, string boneName = null) => getPhysicsLinearVelocityAtPoint(Pointer, ref value, point, boneName);
 
-        /// <summary>
-        /// Retrieves the linear velocity of a point on a single body
-        /// </summary>
-        public Vector3 GetPhysicsLinearVelocityAtPoint(in Vector3 point, string boneName = null) {
-            Vector3 value = default;
-            getPhysicsLinearVelocityAtPoint(Pointer, ref value, point, boneName);
-            return value;
-        }
+		/// <summary>
+		/// Retrieves the linear velocity of a point on a single body
+		/// </summary>
+		public Vector3 GetPhysicsLinearVelocityAtPoint(in Vector3 point, string boneName = null) {
+			Vector3 value = default;
+			getPhysicsLinearVelocityAtPoint(Pointer, ref value, point, boneName);
+			return value;
+		}
 
 		/// <summary>
 		/// Retrieves the angular velocity in degrees of a single body and returns to a reference
 		/// </summary>
 		public void GetPhysicsAngularVelocityInDegrees(ref Vector3 value, string boneName = null) => getPhysicsAngularVelocityInDegrees(Pointer, ref value, boneName);
 
-        /// <summary>
-        /// Retrieves the angular velocity in degrees of a single body
-        /// </summary>
-        public Vector3 GetPhysicsAngularVelocityInDegrees(string boneName = null) {
-            Vector3 value = default;
-            getPhysicsAngularVelocityInDegrees(Pointer, ref value, boneName);
-            return value;
-        }
+		/// <summary>
+		/// Retrieves the angular velocity in degrees of a single body
+		/// </summary>
+		public Vector3 GetPhysicsAngularVelocityInDegrees(string boneName = null) {
+			Vector3 value = default;
+			getPhysicsAngularVelocityInDegrees(Pointer, ref value, boneName);
+			return value;
+		}
 
 		/// <summary>
 		/// Retrieves the angular velocity in radians of a single body and returns to a reference
 		/// </summary>
 		public void GetPhysicsAngularVelocityInRadians(ref Vector3 value, string boneName = null) => getPhysicsAngularVelocityInRadians(Pointer, ref value, boneName);
 
-        /// <summary>
-        /// Retrieves the angular velocity in radians of a single body
-        /// </summary>
-        public Vector3 GetPhysicsAngularVelocityInRadians(string boneName = null) {
-            Vector3 value = default;
-            getPhysicsAngularVelocityInRadians(Pointer, ref value, boneName);
-            return value;
-        }
+		/// <summary>
+		/// Retrieves the angular velocity in radians of a single body
+		/// </summary>
+		public Vector3 GetPhysicsAngularVelocityInRadians(string boneName = null) {
+			Vector3 value = default;
+			getPhysicsAngularVelocityInRadians(Pointer, ref value, boneName);
+			return value;
+		}
 
 		/// <summary>
 		/// Returns the material at the specified element index
@@ -7470,28 +7470,28 @@ namespace UnrealEngine.Framework {
 		/// </summary>
 		public void GetScaledBoxExtent(ref Vector3 value) => getScaledBoxExtent(Pointer, ref value);
 
-        /// <summary>
-        /// Retrieves the box extents scaled by the component scale
-        /// </summary>
-        public Vector3 GetScaledBoxExtent() {
-            Vector3 value = default;
-            getScaledBoxExtent(Pointer, ref value);
-            return value;
-        }
+		/// <summary>
+		/// Retrieves the box extents scaled by the component scale
+		/// </summary>
+		public Vector3 GetScaledBoxExtent() {
+			Vector3 value = default;
+			getScaledBoxExtent(Pointer, ref value);
+			return value;
+		}
 
 		/// <summary>
 		/// Retrieves the box extent ignoring the component scale and returns to a reference
 		/// </summary>
 		public void GetUnscaledBoxExtent(ref Vector3 value) => getUnscaledBoxExtent(Pointer, ref value);
 
-        /// <summary>
-        /// Retrieves the box extent ignoring the component scale
-        /// </summary>
-        public Vector3 GetUnscaledBoxExtent() {
-            Vector3 value = default;
-            getUnscaledBoxExtent(Pointer, ref value);
-            return value;
-        }
+		/// <summary>
+		/// Retrieves the box extent ignoring the component scale
+		/// </summary>
+		public Vector3 GetUnscaledBoxExtent() {
+			Vector3 value = default;
+			getUnscaledBoxExtent(Pointer, ref value);
+			return value;
+		}
 
 		/// <summary>
 		/// Sets the box extent size, unscaled before the component scale is applied


### PR DESCRIPTION
e.g

``` C#
/// <summary>
/// Retrieves the current size of the viewport and returns to a reference
/// </summary>
public static void GetViewportSize(ref Vector2 value) => getViewportSize(ref value);

/// <summary>
/// Retrieves the current size of the viewport
/// </summary>
public static Vector2 GetViewportSize() {
    Vector2 value = default;
    getViewportSize(ref value);
    return value;
}
```