### PR TITLE
Reserve memory for `AddInstances`  and `BatchUpdateInstanceTransforms` call before adding items

### DIFF
--- a/Source/Native/Source/UnrealCLR/Private/UnrealCLRFramework.cpp
+++ b/Source/Native/Source/UnrealCLR/Private/UnrealCLRFramework.cpp
@@ -3441,6 +3441,7 @@ namespace UnrealCLRFramework {
 		bool BatchUpdateInstanceTransforms(UInstancedStaticMeshComponent* InstancedStaticMeshComponent, int32 StartInstanceIndex, int32 EndInstanceIndex, const Transform InstanceTransforms[], bool WorldSpace, bool MarkRenderStateDirty, bool Teleport) {
 			static TArray<FTransform> instanceTransforms;
 
+			instanceTransforms.Reserve(EndInstanceIndex - StartInstanceIndex);
 			instanceTransforms.Reset();
 
 			for (int32 i = 0; i < EndInstanceIndex; i++) {

--- a/Source/Native/Source/UnrealCLR/Private/UnrealCLRFramework.cpp
+++ b/Source/Native/Source/UnrealCLR/Private/UnrealCLRFramework.cpp
@@ -3441,10 +3441,10 @@ namespace UnrealCLRFramework {
 		bool BatchUpdateInstanceTransforms(UInstancedStaticMeshComponent* InstancedStaticMeshComponent, int32 StartInstanceIndex, int32 EndInstanceIndex, const Transform InstanceTransforms[], bool WorldSpace, bool MarkRenderStateDirty, bool Teleport) {
 			static TArray<FTransform> instanceTransforms;
 
-			instanceTransforms.Reserve(EndInstanceIndex - StartInstanceIndex);
+			instanceTransforms.Reserve(EndInstanceIndex + 1);
 			instanceTransforms.Reset();
 
-			for (int32 i = 0; i < EndInstanceIndex - StartInstanceIndex; i++) {
+			for (int32 i = 0; i < EndInstanceIndex; i++) {
 				instanceTransforms.Add(InstanceTransforms[i]);
 			}
 

--- a/Source/Native/Source/UnrealCLR/Private/UnrealCLRFramework.cpp
+++ b/Source/Native/Source/UnrealCLR/Private/UnrealCLRFramework.cpp
@@ -3444,7 +3444,7 @@ namespace UnrealCLRFramework {
 			instanceTransforms.Reserve(EndInstanceIndex - StartInstanceIndex);
 			instanceTransforms.Reset();
 
-			for (int32 i = 0; i < EndInstanceIndex; i++) {
+			for (int32 i = 0; i < EndInstanceIndex - StartInstanceIndex; i++) {
 				instanceTransforms.Add(InstanceTransforms[i]);
 			}
 

--- a/Source/Native/Source/UnrealCLR/Private/UnrealCLRFramework.cpp
+++ b/Source/Native/Source/UnrealCLR/Private/UnrealCLRFramework.cpp
@@ -3424,6 +3424,7 @@ namespace UnrealCLRFramework {
 		void AddInstances(UInstancedStaticMeshComponent* InstancedStaticMeshComponent, int32 EndInstanceIndex, const Transform InstanceTransforms[]) {
 			static TArray<FTransform> instanceTransforms;
 
+			instanceTransforms.Reserve(EndInstanceIndex + 1);
 			instanceTransforms.Reset();
 
 			for (int32 i = 0; i < EndInstanceIndex; i++) {


### PR DESCRIPTION
I thinks should be reasonable because if one adds 1k+ items I'm not sure how well the TArray will behave if it constantly has to reallocate. Besides, no need to allocate more memory than needed.