### PR TITLE
Fix unresolved symbol when calling blueprint library from C++

### DIFF
--- a/Source/Native/Source/UnrealCLR/Private/UnrealCLRLibrary.cpp
+++ b/Source/Native/Source/UnrealCLR/Private/UnrealCLRLibrary.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "UnrealCLRLibrary.h"
+#include "UnrealCLR.h"
 
 FManagedFunction::FManagedFunction() : Pointer() { }
 

--- a/Source/Native/Source/UnrealCLR/Private/UnrealCLRLibrary.cpp
+++ b/Source/Native/Source/UnrealCLR/Private/UnrealCLRLibrary.cpp
@@ -22,7 +22,6 @@
  */
 
 #include "UnrealCLRLibrary.h"
-#include "UnrealCLR.h"
 
 FManagedFunction::FManagedFunction() : Pointer() { }
 

--- a/Source/Native/Source/UnrealCLR/Public/UnrealCLRLibrary.h
+++ b/Source/Native/Source/UnrealCLR/Public/UnrealCLRLibrary.h
@@ -38,7 +38,7 @@ struct UNREALCLR_API FManagedFunction {
 };
 
 UCLASS()
-class UUnrealCLRLibrary : public UBlueprintFunctionLibrary {
+class UNREALCLR_API UUnrealCLRLibrary : public UBlueprintFunctionLibrary {
 	GENERATED_UCLASS_BODY()
 
 	public:
@@ -51,7 +51,7 @@ class UUnrealCLRLibrary : public UBlueprintFunctionLibrary {
 };
 
 UCLASS()
-class UUnrealCLRCharacter : public UObject {
+class UNREALCLR_API UUnrealCLRCharacter : public UObject {
 	GENERATED_UCLASS_BODY()
 
 	public:


### PR DESCRIPTION
When trying to call static functions from cpp, I was unable to resolve the symbol because the UNREALCLR_API macro is missing from these two function declarations. 

This fixes the problem.