### PR TITLE
Unreal Engine 5 compatibility update

### DIFF
--- a/API/Bounds-SphereRadius.md
+++ b/API/Bounds-SphereRadius.md
@@ -2,7 +2,7 @@
 ## Bounds.SphereRadius Property
 Returns the radius of the bounding sphere  
 ```csharp
-public float SphereRadius { get; }
+public double SphereRadius { get; }
 ```
 #### Property Value
 [System.Single](https://docs.microsoft.com/en-us/dotnet/api/System.Single 'System.Single')  

--- a/API/ControllerHand.md
+++ b/API/ControllerHand.md
@@ -27,49 +27,51 @@ public enum ControllerHand : System.Byte
   
 <a name='ControllerHand-Gun'></a>
 `Gun` 5  
+
+
+<a name='ControllerHand-HMD'></a>
+`HMD` 6  
   
-  
+   
 <a name='ControllerHand-Special1'></a>
-`Special1` 6  
+`Special1` 7  
   
   
 <a name='ControllerHand-Special2'></a>
-`Special2` 7  
+`Special2` 8  
   
   
 <a name='ControllerHand-Special3'></a>
-`Special3` 8  
+`Special3` 9  
   
   
 <a name='ControllerHand-Special4'></a>
-`Special4` 9  
+`Special4` 10  
   
   
 <a name='ControllerHand-Special5'></a>
-`Special5` 10  
+`Special5` 11  
   
   
 <a name='ControllerHand-Special6'></a>
-`Special6` 11  
+`Special6` 12  
   
   
 <a name='ControllerHand-Special7'></a>
-`Special7` 12  
+`Special7` 13  
   
   
 <a name='ControllerHand-Special8'></a>
-`Special8` 13  
+`Special8` 14  
   
   
 <a name='ControllerHand-Special9'></a>
-`Special9` 14  
+`Special9` 15  
   
   
 <a name='ControllerHand-Special10'></a>
-`Special10` 15  
+`Special10` 16  
   
   
 <a name='ControllerHand-Special11'></a>
-`Special11` 16  
-  
-  
+`Special11` 17  

--- a/API/PixelFormat.md
+++ b/API/PixelFormat.md
@@ -291,5 +291,55 @@ public enum PixelFormat
   
 <a name='PixelFormat-R8'></a>
 `R8` 71  
+
+
+<a name='PixelFormat-B5G5R5A1UNorm'></a>
+`B5G5R5A1UNorm` 72  
   
   
+<a name='PixelFormat-ASTC4x4HDR'></a>
+`ASTC4x4HDR` 73  
+  
+  
+<a name='PixelFormat-ASTC6x6HDR'></a>
+`ASTC6x6HDR` 74  
+  
+  
+<a name='PixelFormat-ASTC8x8HDR'></a>
+`ASTC8x8HDR` 75  
+  
+  
+<a name='PixelFormat-ASTC10x10HDR'></a>
+`ASTC10x10HDR` 76  
+
+
+<a name='PixelFormat-ASTC12x12HDR'></a>
+`ASTC12x12HDR` 77  
+  
+  
+<a name='PixelFormat-G16R16SNorm'></a>
+`G16R16SNorm` 78  
+  
+  
+<a name='PixelFormat-R8G8UInt'></a>
+`R8G8UInt` 79  
+  
+  
+<a name='PixelFormat-R32G32B32UInt'></a>
+`R32G32B32UInt` 80  
+  
+  
+<a name='PixelFormat-R32G32B32SInt'></a>
+`R32G32B32SInt` 81  
+  
+  
+<a name='PixelFormat-R32G32B32F'></a>
+`R32G32B32F` 82  
+  
+  
+<a name='PixelFormat-R8SInt'></a>
+`R8SInt` 83  
+  
+  
+<a name='PixelFormat-R64UInt'></a>
+`R64UInt` 84  

--- a/Source/Managed/Framework/Framework.cs
+++ b/Source/Managed/Framework/Framework.cs
@@ -633,6 +633,8 @@ namespace UnrealEngine.Framework {
 		/// <summary/>
 		Gun,
 		/// <summary/>
+		HMD,
+		/// <summary/>
 		Special1,
 		/// <summary/>
 		Special2,
@@ -901,7 +903,33 @@ namespace UnrealEngine.Framework {
 		/// <summary/>
 		ETC2RG11EAC = 70,
 		/// <summary/>
-		R8 = 71
+		R8 = 71,
+		/// <summary/>
+		B5G5R5A1UNorm = 72,
+		/// <summary/>
+		ASTC4x4HDR = 73,
+		/// <summary/>
+		ASTC6x6HDR = 74,
+		/// <summary/>
+		ASTC8x8HDR = 75,
+		/// <summary/>
+		ASTC10x10HDR = 76,
+		/// <summary/>
+		ASTC12x12HDR = 77,
+		/// <summary/>
+		G16R16SNorm = 78,
+		/// <summary/>
+		R8G8UInt = 79, 
+		/// <summary/>
+		R32G32B32UInt = 80, 
+		/// <summary/>
+		R32G32B32SInt = 81, 
+		/// <summary/>
+		R32G32B32F = 82,
+		/// <summary/>
+		R8SInt = 83, 
+		/// <summary/>
+		R64UInt = 84, 
 	}
 
 	/// <summary>
@@ -1710,7 +1738,7 @@ namespace UnrealEngine.Framework {
 		/// <summary>
 		/// Returns the radius of the bounding sphere
 		/// </summary>
-		public float SphereRadius => sphereRadius;
+		public double SphereRadius => sphereRadius;
 
 		/// <summary>
 		/// Tests for equality between two objects

--- a/Source/Native/Source/UnrealCLR/Private/UnrealCLRFramework.cpp
+++ b/Source/Native/Source/UnrealCLR/Private/UnrealCLRFramework.cpp
@@ -384,6 +384,9 @@ namespace UnrealCLRFramework {
 	#define UNREALCLR_COLOR_TO_INTEGER(Color) (Color.A << 24) + (Color.R << 16) + (Color.G << 8) + Color.B
 
 	#if ENGINE_MAJOR_VERSION == 4
+		#define UNREALCLR_CONTROLLER_HAND 17
+		#define UNREALCLR_BOUNDS_SIZE 28
+
 		#if ENGINE_MINOR_VERSION <= 26
 			#define UNREALCLR_BLEND_TYPE 5
 		#elif ENGINE_MINOR_VERSION >= 27
@@ -396,20 +399,37 @@ namespace UnrealCLRFramework {
 			#define UNREALCLR_PIXEL_FORMAT 72
 		#endif
 	#elif ENGINE_MAJOR_VERSION == 5
-		#define UNREALCLR_PIXEL_FORMAT 72
 		#define UNREALCLR_BLEND_TYPE 6
+		#define UNREALCLR_PIXEL_FORMAT 85
+		#define UNREALCLR_CONTROLLER_HAND 18
+
+		// Large World Coordinates changed to double sphere radius to double but will be refactored to double in UE5 stable release. 
+		// Currently this is aliased to FLargeWorldCoordinatesReal. Check Engine\Source\Runtime\CoreUObject\Public\UObject\NoExportTypes.h for FVector where it explains.
+		#define UNREALCLR_BOUNDS_SIZE 56	
+
+		#ifdef BRANCH_NAME
+			// There may be a better way to get this information
+			#ifdef BRANCH_NAME == "++UE5+Release-5.0-EarlyAccess"
+				#define UNREALCLR_PIXEL_FORMAT 72
+			#else 
+				#define UNREALCLR_PIXEL_FORMAT 85
+			#endif
+		#else
+			#define UNREALCLR_PIXEL_FORMAT 85
+		#endif
+
 	#endif
 
 	static_assert(AudioFadeCurve::Count == AudioFadeCurve(4), "Invalid elements count of the [AudioFadeCurve] enumeration");
 	static_assert(BlendType::VTBlend_MAX == BlendType(UNREALCLR_BLEND_TYPE), "Invalid elements count of the [BlendType] enumeration");
 	static_assert(CollisionChannel::ECC_MAX == CollisionChannel(33), "Invalid elements count of the [CollisionChannel] enumeration");
 	static_assert(CollisionResponse::ECR_MAX == CollisionResponse(3), "Invalid elements count of the [CollisionResponse] enumeration");
-	static_assert(ControllerHand::ControllerHand_Count == ControllerHand(17), "Invalid elements count of the [ControllerHand] enumeration");
+	static_assert(ControllerHand::ControllerHand_Count == ControllerHand(UNREALCLR_CONTROLLER_HAND), "Invalid elements count of the [ControllerHand] enumeration");
 	static_assert(InputEvent::IE_MAX == InputEvent(5), "Invalid elements count of the [InputEvent] enumeration");
 	static_assert(NetMode::NM_MAX == NetMode(4), "Invalid elements count of the [NetMode] enumeration");
 	static_assert(PixelFormat::PF_MAX == PixelFormat(UNREALCLR_PIXEL_FORMAT), "Invalid elements count of the [PixelFormat] enumeration");
 
-	static_assert(sizeof(Bounds) == 28, "Invalid size of the [Bounds] structure");
+	static_assert(sizeof(Bounds) == UNREALCLR_BOUNDS_SIZE, "Invalid size of the [Bounds] structure");
 	static_assert(sizeof(CollisionShape) == 16, "Invalid size of the [CollisionShape] structure");
 
 	namespace Assert {
@@ -982,7 +1002,11 @@ namespace UnrealCLRFramework {
 
 	namespace Engine {
 		bool IsSplitScreen() {
+#if ENGINE_MAJOR_VERSION >= 5
+			return GEngine->HasMultipleLocalPlayers(UnrealCLR::Engine::World);
+#else
 			return GEngine->IsSplitScreen(UnrealCLR::Engine::World);
+#endif
 		}
 
 		bool IsEditor() {

--- a/Source/Native/Source/UnrealCLR/Private/UnrealCLRFramework.cpp
+++ b/Source/Native/Source/UnrealCLR/Private/UnrealCLRFramework.cpp
@@ -403,7 +403,7 @@ namespace UnrealCLRFramework {
 		#define UNREALCLR_PIXEL_FORMAT 85
 		#define UNREALCLR_CONTROLLER_HAND 18
 
-		// Large World Coordinates changed to double sphere radius to double but will be refactored to double in UE5 stable release. 
+		// Large World Coordinates changed float sphere radius to double but this will be refactored to double in UE5 stable release. 
 		// Currently this is aliased to FLargeWorldCoordinatesReal. Check Engine\Source\Runtime\CoreUObject\Public\UObject\NoExportTypes.h for FVector where it explains.
 		#define UNREALCLR_BOUNDS_SIZE 56	
 


### PR DESCRIPTION
This PR contains the start of a migration to UE5 Preview. I struggled to find a way to get a macro that associates UE5 with Preview instead of Early Access. Closest I could find was the BRANCH_NAME macro. Maybe @nxrighthere  you know of a better way? I guess once UE5 stable is out Early Access won't need to be supported. 

There is also a deprecated warning for UObject->IsPendingKill function. I've left that out for now, I imagine if it is being deprecated we could just omit it in UE5.

Hope this helps!